### PR TITLE
Adding appInsight monitoring support

### DIFF
--- a/azurecosmos/conf/azurecosmos.properties
+++ b/azurecosmos/conf/azurecosmos.properties
@@ -89,3 +89,6 @@
 
 # output file location
 # exportfile =
+
+# application insight connection String
+# azurecosmos.appInsightConnectionString =

--- a/azurecosmos/pom.xml
+++ b/azurecosmos/pom.xml
@@ -56,5 +56,10 @@ LICENSE file.
       <version>${project.version}</version>
     <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-azure-monitor</artifactId>
+      <version>1.9.2</version> <!-- {x-version-update;io.micrometer:micrometer-registry-azure-monitor;external_dependency} -->
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
This is opt in choice if user want to track the live performance during the run. 
They need to provide azurecosmos.appInsightConnectionString in azurecosmos.properties.
Below is an example screen shot from app insight ui
![image](https://user-images.githubusercontent.com/43345335/187234699-4ddf7a71-5b9f-4d8f-be82-bc61e0102185.png)
 