### PR TITLE
Update pr-builder.yml to use Java 8 only

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [11, 17]
+        java: [8] # Older Zookeepers will not start when using Java 11 so Java 8 it is for now
 
     steps:
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3


### PR DESCRIPTION
Use Java 8 only as the underlying Zookeeper for older versions of Hadoop et al can't start properly with Java 11+.